### PR TITLE
[account]/chore: added config to override fetch request with no-cache

### DIFF
--- a/src/utils/initialize-i18n.ts
+++ b/src/utils/initialize-i18n.ts
@@ -9,7 +9,11 @@ type TInstanceConfig = {
   enableDebug?: InitOptions["debug"];
 };
 
-const setI18Config = ({ useSuspense, enableDebug }: TInstanceConfig) => ({
+const setI18Config = ({
+  useSuspense,
+  enableDebug,
+}: TInstanceConfig): InitOptions => ({
+  load: "languageOnly",
   react: {
     hashTransKey(defaultValue: string) {
       return crc32(defaultValue);

--- a/src/utils/otasdk.ts
+++ b/src/utils/otasdk.ts
@@ -17,7 +17,9 @@ export default class OtaI18next implements OtaI18nextModule {
   }
 
   read(language: string, _namespace: string, callback: ReadCallback) {
-    fetch(this.cdnUrl + "/translations/" + language.toLowerCase() + ".json")
+    fetch(`${this.cdnUrl}/translations/${language.toLowerCase()}.json`, {
+      cache: "no-cache",
+    })
       .then((res) => {
         if (!res.ok) {
           throw new Error("Failed to fetch translations");


### PR DESCRIPTION
The translation resource once requested is cached by browser. This prevents the browser from fetching any new changes of the resource.

To prevent this, the fetch request is configured with no-cache option