### PR TITLE
fix: Next.js App Router SSR compatibility and build config bugs

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -25,6 +25,7 @@
         "@testing-library/jest-dom": "^6.9.1",
         "@testing-library/react": "^16.3.2",
         "@testing-library/user-event": "^14.6.1",
+        "@types/node": "^25.6.0",
         "@types/react": "^19.2.14",
         "@types/react-dom": "^19.2.3",
         "@typescript-eslint/eslint-plugin": "^8.58.0",
@@ -2320,6 +2321,16 @@
       "integrity": "sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@types/node": {
+      "version": "25.6.0",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-25.6.0.tgz",
+      "integrity": "sha512-+qIYRKdNYJwY3vRCZMdJbPLJAtGjQBudzZzdzwQYkEPQd+PJGixUL5QfvCLDaULoLv+RhT3LDkwEfKaAkgSmNQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~7.19.0"
+      }
     },
     "node_modules/@types/normalize-package-data": {
       "version": "2.4.4",
@@ -10415,6 +10426,13 @@
       "engines": {
         "node": ">=20.18.1"
       }
+    },
+    "node_modules/undici-types": {
+      "version": "7.19.2",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.19.2.tgz",
+      "integrity": "sha512-qYVnV5OEm2AW8cJMCpdV20CDyaN3g0AjDlOGf1OW4iaDEx8MwdtChUp4zu4H0VP3nDRF/8RKWH+IPp9uW0YGZg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/unicode-emoji-modifier-base": {
       "version": "1.0.0",

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     "@testing-library/jest-dom": "^6.9.1",
     "@testing-library/react": "^16.3.2",
     "@testing-library/user-event": "^14.6.1",
+    "@types/node": "^25.6.0",
     "@types/react": "^19.2.14",
     "@types/react-dom": "^19.2.3",
     "@typescript-eslint/eslint-plugin": "^8.58.0",

--- a/src/hooks/use-translations.ts
+++ b/src/hooks/use-translations.ts
@@ -1,3 +1,5 @@
+"use client";
+
 import { useTranslation } from "react-i18next";
 import { useContext } from "react";
 import { TranslationContext } from "@/provider/index";

--- a/src/provider/translation-provider.tsx
+++ b/src/provider/translation-provider.tsx
@@ -1,3 +1,5 @@
+"use client";
+
 import { createContext, useEffect, useState } from "react";
 import { I18nextProvider } from "react-i18next";
 

--- a/tsconfig.node.json
+++ b/tsconfig.node.json
@@ -4,7 +4,8 @@
     "skipLibCheck": true,
     "module": "ESNext",
     "moduleResolution": "bundler",
-    "allowSyntheticDefaultImports": true
+    "allowSyntheticDefaultImports": true,
+    "types": ["node"]
   },
   "include": ["vite.config.ts"]
 }

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,10 +1,11 @@
-/// <reference types="vitest" />
 import react from "@vitejs/plugin-react";
-import { defineConfig } from "vite";
-import { resolve, relative, extname } from "path";
+import { defineConfig } from "vitest/config";
+import { resolve, relative, extname, dirname } from "path";
 import { fileURLToPath } from "node:url";
 import dts from "vite-plugin-dts";
 import { glob } from "glob";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
 
 // https://vitejs.dev/config/
 export default defineConfig({
@@ -15,13 +16,11 @@ export default defineConfig({
       formats: ["es"],
     },
     rollupOptions: {
-      external: ["react", "react-dom", "react-dom/client"],
+      external: ["react", "react-dom", "react-dom/client", "react-i18next", "i18next"],
       output: {
-        assetFileNames: "assets/[name]",
+        assetFileNames: "assets/[name][extname]",
         entryFileNames: "[name].js",
-        globals: {
-          react: "React",
-        },
+        chunkFileNames: "[name]-[hash].js",
       },
       input: Object.fromEntries(
         glob
@@ -65,6 +64,9 @@ export default defineConfig({
         "setupTests.ts",
         "src/**/*.test.tsx",
         "src/**/*.test.ts",
+        "src/**/*.spec.tsx",
+        "src/**/*.spec.ts",
+        "src/**/__tests__/**",
         "src/playground/*.tsx",
         "src/playground/*.ts",
         "src/playground/*.css",


### PR DESCRIPTION
## Summary
- Add `"use client"` to `TranslationProvider` and `useTranslations` so
  Next.js App Router excludes them from the server bundle, fixing the
  `createContext is not a function` crash on the server
- Externalize `react-i18next` and `i18next` to prevent Rolldown from
  emitting a CJS shim that calls `require("react")` in the browser
- Fix 6 build config bugs in `vite.config.ts`: undefined `__dirname`
  in ESM, wrong `defineConfig` import, missing asset extension, dead
  `globals` config, missing `chunkFileNames`, incomplete `dts` excludes
- Add `@types/node` dev dep + `tsconfig.node.json` `types: ["node"]`

## Test plan
- [ ] `npm run build` completes without errors
- [ ] Install built package in a Next.js App Router project — no
  `createContext` or `require` errors
- [ ] Install in a plain Vite/CRA project — no regressions
- [ ] `npm run test` passes