### PR TITLE
fix: add "use client" to index.ts to prevent RSC execution

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,3 +1,5 @@
+"use client";
+
 export {
   localize,
   getInitialLanguage,


### PR DESCRIPTION
initializeI18n imports initReactI18next from react-i18next at module level, which Rollup bundles into a shared chunk. When a server component imports anything from the package, that chunk executes on the server and calls createContext() on the stripped RSC React runtime, crashing with "createContext is not a function".

Marking the main entry as "use client" makes Next.js App Router treat the entire package as a client boundary and stops execution on the server.